### PR TITLE
Add option to select interface for mpirun using --mca 

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -275,6 +275,7 @@ int init(char** argv, int argc) {
     arg_decl_bool_w_def("bwa.enforce_order",       false,  "enforce strict sorting ordering")
     arg_decl_string_w_def("bwa.fpga.bit_path",     conf_root_dir+"/tools/package/bitstream.xclbin", "path to FPGA bitstream for bwa")
     arg_decl_string_w_def("bwa.fpga.pac_path",     "",    "(deprecated) path to PAC reference used by FPGA for bwa")
+    arg_decl_string("bwa.mpi_if", "network interface to use mpi connection")
     arg_decl_bool("bwa.scaleout_mode", "enable scale-out mode for bwa")
 
     arg_decl_int_w_def("markdup.max_files",    4096, "max opened files in markdup")

--- a/src/workers/BWAWorker.cpp
+++ b/src/workers/BWAWorker.cpp
@@ -55,7 +55,11 @@ void BWAWorker::setup() {
     // is set in user's bash mode
     cmd << get_config<std::string>("mpi_path") << "/bin/mpirun " 
         << "--prefix " << get_config<std::string>("mpi_path") << " "
-        << "--bind-to none "
+        << "--bind-to none ";
+    if (check_config("bwa.mpi_if")) {
+      cmd << "--mca oob_tcp_if_include " << get_config<std::string>("bwa.mpi_if") << " "
+          << "--mca btl_tcp_if_include " << get_config<std::string>("bwa.mpi_if") << " ";
+    }
         /* 
          * This '--mca' option is used to get rid of the problem of
          * hfi_wait_for_device which causes a 15 sec delay.
@@ -63,7 +67,7 @@ void BWAWorker::setup() {
          * Source: 
          * http://users.open-mpi.narkive.com/7efFnJXR/ompi-users-device-failed-to-appear-connection-timed-out
          */
-        << "--mca pml ob1 "
+    cmd << "--mca pml ob1 "
         << "--allow-run-as-root "
         << "-np " << conf_host_list.size() << " ";
 


### PR DESCRIPTION
This is to solve the issue when there are multiple network interfaces in the system and the default one does not reach all the hosts in the network. Error message looks like this:
```
send() to socket 9 failed: Broken pipe (32)
```
It can be solved according to [this article](https://www.mail-archive.com/users@lists.open-mpi.org/msg32000.html) by adding the following two arguments in `mpirun`:
```
--mca oob_tcp_if_include eth0 --mca btl_tcp_if_include eth0
```

We add this feature using a new config key *bwa.mpi_if*