### PR TITLE
GEN-429: Start NAM in the background

### DIFF
--- a/include/fcs-genome/BackgroundExecutor.h
+++ b/include/fcs-genome/BackgroundExecutor.h
@@ -1,0 +1,22 @@
+#ifndef FCS_GENOME_BACKGROUNDEXECUTOR_H
+#define FCS_GENOME_BACKGROUNDEXECUTOR_H
+#include <boost/smart_ptr.hpp>
+
+#include "fcs-genome/common.h"
+#include "fcs-genome/config.h"
+#include "fcs-genome/Executor.h"
+#include "fcs-genome/Worker.h"
+
+namespace fcsgenome {
+
+class BackgroundExecutor : public Executor {
+ public:
+  BackgroundExecutor(std::string job_name, Worker_ptr worker);
+  ~BackgroundExecutor();
+ 
+ private:
+  int child_pid_;
+  std::string job_script_;
+};
+} // namespace fcsgenome
+#endif

--- a/include/fcs-genome/common.h
+++ b/include/fcs-genome/common.h
@@ -232,6 +232,8 @@ void get_input_list(std::string path,
 std::vector<std::string> get_lines(std::string fname,
     std::string pattern = ".*");
 
+uint32_t getTid();
+
 class Executor;
 class Worker;
 

--- a/include/fcs-genome/workers.h
+++ b/include/fcs-genome/workers.h
@@ -1,6 +1,7 @@
 #ifndef FCSGENOME_WORKERS_H
 #define FCSGENOME_WORKERS_H
 
+#include "workers/BlazeWorker.h"
 #include "workers/BQSRWorker.h"
 #include "workers/BWAWorker.h"
 #include "workers/CombineGVCFsWorker.h"

--- a/include/fcs-genome/workers/BlazeWorker.h
+++ b/include/fcs-genome/workers/BlazeWorker.h
@@ -1,0 +1,20 @@
+#ifndef FCSGENOME_WORKERS_BLAZEWORKER_H
+#define FCSGENOME_WORKERS_BLAZEWORKER_H
+
+#include <string>
+#include "fcs-genome/Worker.h"
+
+namespace fcsgenome {
+
+class BlazeWorker : public Worker {
+ public:
+  BlazeWorker(std::string nam_path, std::string conf_path);
+  void check();
+  void setup();
+
+ private:
+  std::string nam_path_;
+  std::string conf_path_;
+};
+} // namespace fcsgenome
+#endif

--- a/src/BackgroundExecutor.cpp
+++ b/src/BackgroundExecutor.cpp
@@ -1,0 +1,86 @@
+#include <csignal>
+#include <iostream>
+#include <fstream>
+#include <string>
+#include <sys/stat.h>
+#include <sys/wait.h>
+
+#include "fcs-genome/common.h"
+#include "fcs-genome/BackgroundExecutor.h"
+
+namespace fcsgenome {
+
+BackgroundExecutor::BackgroundExecutor(
+    std::string job_name, 
+    Worker_ptr worker): Executor(job_name, 1)
+{
+  // start worker in the background in constructor
+  worker->check();
+
+  worker->setup();
+
+  create_dir(get_config<std::string>("log_dir"));
+  std::string log = get_log_name(job_name);
+  std::string cmd = worker->getCommand() + " 2> " + log;
+
+  // fork and execute cmd using system call
+  int pid = fork();
+  if (pid) {
+    // parent task
+    child_pid_ = pid;
+    DLOG(INFO) << "Started proc " << pid << " in the background";
+  }
+  else {
+    // child task
+    DLOG(INFO) << cmd;
+
+    // create a wrapper script to run command
+    std::string temp_dir = conf_temp_dir + "/background_executor";
+    create_dir(temp_dir);
+
+    std::string script_file = temp_dir + "/job-" + job_name + ".sh";
+
+    std::stringstream cmd_sh;
+    cmd_sh << "trap 'kill $(jobs -p)' EXIT" << std::endl;
+    cmd_sh << cmd << std::endl;
+
+    // write the script to file
+    std::ofstream fout;
+    fout.open(script_file);
+    if (!fout) {
+      DLOG(ERROR) << "cannot write to " << script_file;    
+      throw internalError("cannot start nam");
+    }
+    fout << cmd_sh.rdbuf();
+    fout.close();
+
+    job_script_ = script_file;
+
+    // add x flag to script
+    if (chmod(script_file.c_str(), S_IRWXU)) {
+      DLOG(ERROR) << "cannot chmod +x on " << script_file;    
+      throw internalError("cannot start nam");
+    }
+
+    //setsid();
+    execl("/bin/sh", "sh", "-c", script_file.c_str(), (char*)0);
+
+    remove_path(script_file);
+    //int ret = system(cmd.c_str());
+    //if (ret && !interrupted_) {
+    //  LOG(WARNING) << "Background task has none zero ret";
+    //}
+  }
+}
+
+BackgroundExecutor::~BackgroundExecutor() {
+  // send a signal and kill process
+  DLOG(INFO) << "Send a signal to child process " << child_pid_ << " to terminate";
+  kill(child_pid_, SIGALRM);
+  if (!job_script_.empty()) {
+    remove_path(job_script_);
+    DLOG(INFO) << "deleted " << job_script_;
+  }
+}
+
+} // namespace fcsgenome

--- a/src/Executor.cpp
+++ b/src/Executor.cpp
@@ -27,6 +27,11 @@ void sigint_handler(int s){
     DLOG(INFO) << "Deleting the executor";
     delete g_executor;
   }
+
+  // delete temp folder
+#ifndef NDEBUG
+  remove_path(conf_temp_dir);
+#endif
   exit(1);
 }
 

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -21,6 +21,25 @@ Executor* create_executor(std::string job_name, int num_workers) {
   return executor;
 }
 
+uint32_t getTid() {
+  static bool lacks_gettid = false;
+
+  if (!lacks_gettid) {
+    pid_t tid = syscall(__NR_gettid);
+    if (tid != -1) {
+      return (uint32_t)tid;
+    }
+    // Technically, this variable has to be volatile, but there is a small
+    // performance penalty in accessing volatile variables and there should
+    // not be any serious adverse effect if a thread does not immediately see
+    // the value change to "true".
+    lacks_gettid = true;
+  }
+
+  // If gettid() could not be used, we use one of the following.
+  return (uint32_t)getpid(); 
+}
+
 std::string get_absolute_path(std::string path) {
   boost::filesystem::wpath file_path(path);
   if (boost::filesystem::exists(file_path)) {

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -312,6 +312,9 @@ int init(char** argv, int argc) {
     arg_decl_int_w_def("gatk.genotype.nprocs", def_nprocs, "default process num in GATK GenotypeGVCFs")
     arg_decl_int_w_def("gatk.genotype.memory", def_memory, "default heap memory in GATK GenotypeGVCFs")
     arg_decl_bool("gatk.skip_pseudo_chr", "skip pseudo chromosome intervals")
+
+    arg_decl_string_w_def("blaze.nam_path", conf_root_dir+"/tools/blaze/bin/nam", "path to nam in blaze")
+    arg_decl_string_w_def("blaze.conf_path",conf_root_dir+"/tools/blaze/conf",    "path to nam configuration file")
     ;
 
   conf_opt.add(common_opt).add(tools_opt);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -48,7 +48,9 @@ void sigint_handler(int s){
   if (fcsgenome::g_executor) {
     delete fcsgenome::g_executor;
   }
-  
+#ifndef NDEBUG
+  fcsgenome::remove_path(fcsgenome::conf_temp_dir);
+#endif
   exit(0); 
 }
 

--- a/src/worker-htc.cpp
+++ b/src/worker-htc.cpp
@@ -6,6 +6,7 @@
 #include <string>
 
 
+#include "fcs-genome/BackgroundExecutor.h"
 #include "fcs-genome/common.h"
 #include "fcs-genome/config.h"
 #include "fcs-genome/Executor.h"
@@ -77,6 +78,13 @@ int htc_main(int argc, char** argv,
 
   std::vector<std::string> output_files(get_config<int>("gatk.ncontigs"));
   std::vector<std::string> intv_paths = init_contig_intv(ref_path);
+
+  // start an executor for NAM
+  Worker_ptr blaze_worker(new BlazeWorker(
+        get_config<std::string>("blaze.nam_path"),
+        get_config<std::string>("blaze.conf_path")));
+
+  BackgroundExecutor bg_executor("blaze-nam", blaze_worker);
 
   Executor executor("Haplotype Caller", 
                     get_config<int>("gatk.htc.nprocs", "gatk.nprocs"));

--- a/src/worker-mutect2.cpp
+++ b/src/worker-mutect2.cpp
@@ -6,6 +6,7 @@
 #include <string>
 
 
+#include "fcs-genome/BackgroundExecutor.h"
 #include "fcs-genome/common.h"
 #include "fcs-genome/config.h"
 #include "fcs-genome/Executor.h"
@@ -75,6 +76,14 @@ int mutect2_main(int argc, char** argv,
 
   std::vector<std::string> output_files(get_config<int>("gatk.ncontigs"));
   std::vector<std::string> intv_paths = init_contig_intv(ref_path);
+
+  // start an executor for NAM
+  Worker_ptr blaze_worker(new BlazeWorker(
+        get_config<std::string>("blaze.nam_path"),
+        get_config<std::string>("blaze.conf_path")));
+
+  BackgroundExecutor bg_executor("blaze-nam", blaze_worker);
+
 
   Executor executor("Mutect2", get_config<int>("gatk.mutect2.nprocs"));
   

--- a/src/workers/BlazeWorker.cpp
+++ b/src/workers/BlazeWorker.cpp
@@ -1,0 +1,29 @@
+#include <string>
+
+#include "fcs-genome/common.h"
+#include "fcs-genome/config.h"
+#include "fcs-genome/workers/BlazeWorker.h"
+
+namespace fcsgenome {
+
+BlazeWorker::BlazeWorker(std::string nam_path, std::string conf_path): 
+      Worker(1, 1),
+      nam_path_(nam_path),
+      conf_path_(conf_path) 
+{
+  ;  
+}
+
+void BlazeWorker::check() {
+  nam_path_  = check_input(nam_path_);
+  conf_path_ = check_input(conf_path_);
+}
+
+void BlazeWorker::setup() {
+  std::stringstream cmd;
+  cmd << nam_path_ << " " << conf_path_;
+
+  cmd_ = cmd.str();
+}
+
+} // namespace fcsgenome

--- a/test/TestExecutor.cpp
+++ b/test/TestExecutor.cpp
@@ -1,0 +1,86 @@
+#include <boost/filesystem.hpp>
+#include <iostream>
+#include <fstream>
+#include <string>
+#include <gtest/gtest.h>
+
+#include "fcs-genome/BackgroundExecutor.h"
+#include "fcs-genome/common.h"
+#include "fcs-genome/config.h"
+#include "fcs-genome/Worker.h"
+#include "fcs-genome/workers/BlazeWorker.h"
+
+namespace fcs = fcsgenome;
+
+class TestExecutor : public ::testing::Test {
+  ; 
+};
+
+TEST_F(TestExecutor, TestBackgroundExecutor) {
+
+  bool check_done = false;
+  bool setup_done = false;
+
+  // write a file to temp folder
+  std::stringstream fname;
+  fname << "/tmp/TestExecutor." << fcs::getTid() << ".txt";
+  std::fstream fs(fname.str().c_str(), std::ios::out);
+  fs.close();
+
+  ASSERT_TRUE(boost::filesystem::exists(fname.str()));
+
+  class RemoveWorker : public fcs::Worker {
+    public:
+      RemoveWorker(std::string fname, 
+          bool* _check, bool* _setup): 
+            Worker(1, 1), 
+            check_done_(_check),
+            setup_done_(_setup)
+      {
+        cmd_ = "rm " + fname;
+      }
+      void check() { *check_done_ = true; }
+      void setup() { *setup_done_ = true; }
+
+    private:
+      bool* check_done_;
+      bool* setup_done_;
+  };
+
+  class SleepWorker : public fcs::Worker {
+    public:
+      SleepWorker(std::string fname): Worker(1, 1) {
+        cmd_ = "sleep 0.1; touch " + fname;  
+      }
+  };
+  
+  { // check if command is executed
+    fcs::Worker_ptr worker(new RemoveWorker(
+        fname.str(), &check_done, &setup_done));
+  
+    fcs::BackgroundExecutor e("remove", worker);
+
+    ASSERT_TRUE(check_done);
+    ASSERT_TRUE(setup_done);
+
+    // check if file is removed after a while
+    boost::this_thread::sleep_for(boost::chrono::milliseconds(10)); 
+
+    ASSERT_FALSE(boost::filesystem::exists(fname.str()));
+  }
+
+  fcs::Worker_ptr worker(new SleepWorker(
+        fname.str()));
+
+  fcs::BackgroundExecutor* e = new fcs::BackgroundExecutor("sleep", worker);
+
+  // check if file is after a while
+  boost::this_thread::sleep_for(boost::chrono::milliseconds(1));
+  ASSERT_FALSE(boost::filesystem::exists(fname.str()));
+
+  delete e;
+  boost::this_thread::sleep_for(boost::chrono::milliseconds(100)); 
+
+  // shouldn't create this file since the executor is killed
+  ASSERT_FALSE(boost::filesystem::exists(fname.str()));
+}


### PR DESCRIPTION
Created a different Executor called `BackgroundExecutor`, which starts a thread in the background to run a worker, and kills it at destruction.

Added `BlazeWorker` to start Blaze NAM.

Added unit tests and the feature is already tested at AWS & Huawei.