### PR TITLE
Fix(GEN-477): Wrong fcs-genome align error message

### DIFF
--- a/src/worker-align.cpp
+++ b/src/worker-align.cpp
@@ -2,7 +2,6 @@
 #include <boost/filesystem/fstream.hpp>
 #include <boost/program_options.hpp>
 #include <string>
-#include <sys/statvfs.h>
 
 #include "fcs-genome/common.h"
 #include "fcs-genome/config.h"
@@ -112,43 +111,11 @@ int align_main(int argc, char** argv,
   // check available space in temp dir
   namespace fs = boost::filesystem;
 
-  struct statvfs diskData;
-  statvfs(temp_dir.c_str(), &diskData);
-  unsigned long long available = (diskData.f_bavail * diskData.f_frsize);
-  DLOG(INFO) << available;
-
   std::string output_path_temp;
   std::string BAMfile;
   for (auto pair : SampleData) {
     std::string sample_id = pair.first;
     std::vector<SampleDetails> list = pair.second;
-    size_t size_fastq = 0;
-    for (int i = 0; i < list.size(); ++i) {
-        fq1_path = list[i].fastqR1;
-        fq2_path = list[i].fastqR2;
-        // check space occupied by fastq files
-        size_fastq += fs::file_size(fq1_path);
-        size_fastq += fs::file_size(fq2_path);
-
-        DLOG(INFO) << size_fastq;
-
-        // print error message if there is not enough space in temp_dir
-        std::string file_extension;
-        file_extension = fs::extension(fq1_path);
-
-        if (file_extension == ".gz" ) {
-            size_fastq += 3*fs::file_size(fq1_path);
-            size_fastq += 3*fs::file_size(fq2_path);
-        }
-
-        if (available < size_fastq) {
-            LOG(ERROR) << "Not enough space in temporary storage: "
-              << temp_dir << ", the size of the temporary folder should be at least 3 times the input FASTQ files";
-
-            throw silentExit();
-        }
-
-    } // Checking FASTQ files sizes ends
 
     for (int i = 0; i < list.size(); ++i) {
         fq1_path = list[i].fastqR1;

--- a/src/workers/BWAWorker.cpp
+++ b/src/workers/BWAWorker.cpp
@@ -1,4 +1,6 @@
+#include <boost/filesystem.hpp>
 #include <string>
+#include <sys/statvfs.h>
 
 #include "fcs-genome/common.h"
 #include "fcs-genome/config.h"
@@ -44,6 +46,40 @@ void BWAWorker::check() {
   ref_path_ = check_input(ref_path_);
   fq1_path_ = check_input(fq1_path_);
   fq2_path_ = check_input(fq2_path_);
+
+  // check temporary storage
+  auto p = boost::filesystem::path(output_path_);
+  std::string temp_dir = p.parent_path().string();
+
+  struct statvfs diskData;
+  statvfs(temp_dir.c_str(), &diskData);
+  uint64_t available = (diskData.f_bavail * diskData.f_frsize);
+
+  DLOG(INFO) << "The available space in " << temp_dir << " is " << available;
+
+  namespace fs = boost::filesystem;
+  size_t size_fastq = 0;
+
+  std::string ext = fs::extension(fq1_path_);
+  int mult = 1;
+  if (ext == ".gz" ) {
+    mult = 3;
+    size_fastq += 3*fs::file_size(fq1_path_);
+    size_fastq += 3*fs::file_size(fq2_path_);
+  }
+  else {
+    size_fastq += fs::file_size(fq1_path_);
+    size_fastq += fs::file_size(fq2_path_);
+  }
+  DLOG(INFO) << "The size of the input data is " << size_fastq;
+
+  if (available < size_fastq) {
+    LOG(ERROR) << "Not enough space in temporary storage: "
+      << temp_dir << ", "
+      << "the size of the temporary folder should be at least " 
+      << mult << " times the size of input FASTQ files";
+    throw silentExit();
+  }
 }
 
 void BWAWorker::setup() {


### PR DESCRIPTION
Moving file_size check after file existence check, so that it won't report a boost exception when input file doesn't exist. 

In the future, should make sure all the file-related check all happens in Worker::check() routines. We should also add a check for output_path there as well.