### PR TITLE
GEN-512: Error in bqsr with nct > 1

### DIFF
--- a/include/fcs-genome/Worker.h
+++ b/include/fcs-genome/Worker.h
@@ -65,7 +65,6 @@ class Worker {
   std::string log_fname_;
   std::map<std::string, std::vector<std::string> > extra_opts_;
 
- private:
   int num_process_;   // num_processes per task
   int num_thread_;    // num_thread per task process
 };

--- a/src/worker-bqsr.cpp
+++ b/src/worker-bqsr.cpp
@@ -43,7 +43,8 @@ static void baserecalAddWorkers(Executor &executor,
 
     // output bqsr filename
     std::stringstream ss;
-    ss << output_path << "." << contig;
+    std::string temp_dir = conf_temp_dir + "/bqsr";
+    ss << temp_dir << "/" << output_path << "." << contig;
     bqsr_paths[contig] = ss.str();
 
     DLOG(INFO) << "Task " << contig << " bqsr: " << bqsr_paths[contig];


### PR DESCRIPTION
Current GATK 3.8 implementation does not support `nct > 1`. Setup a warning for user, and force reset the value to 1 if the user set it otherwise. 

Also changed the bqsr report parts output folder to temp dir. 