### PR TITLE
GEN-571: intv handling in worker-htc

### DIFF
--- a/include/fcs-genome/workers/IndelWorker.h
+++ b/include/fcs-genome/workers/IndelWorker.h
@@ -33,7 +33,6 @@ class IndelWorker : public Worker {
       std::string target_path,
       std::string output_path,
       std::vector<std::string> extra_opts,
-      std::vector<std::string> &intv_list,
       bool &flag_f);
 
   void check();
@@ -46,7 +45,6 @@ class IndelWorker : public Worker {
   std::string input_path_;
   std::string target_path_;
   std::string output_path_;
-  std::vector<std::string> intv_list_;
 };
 
 

--- a/include/fcs-genome/workers/UGWorker.h
+++ b/include/fcs-genome/workers/UGWorker.h
@@ -13,7 +13,6 @@ class UGWorker : public Worker {
       std::string intv_path,
       std::string output_path,
       std::vector<std::string> extra_opts,
-      std::vector<std::string> &intv_list,
       bool &flag_f);
 
   void check();
@@ -24,7 +23,6 @@ class UGWorker : public Worker {
   std::string intv_path_;
   std::string input_path_;
   std::string output_path_;
-  std::vector<std::string> intv_list_;
 };
 } // namespace fcsgenome
 #endif

--- a/src/worker-bqsr.cpp
+++ b/src/worker-bqsr.cpp
@@ -25,7 +25,7 @@ static void baserecalAddWorkers(Executor &executor,
     bool flag_f, bool flag_gatk)
 {
   std::vector<std::string> intv_paths;
-  if (!intv_list.empty()){
+  if (!intv_list.empty()) {
     intv_paths = split_by_nprocs(intv_list, "bed");
   }
   else {
@@ -89,7 +89,7 @@ static void prAddWorkers(Executor &executor,
   bool flag_f, bool flag_gatk)
 {
   std::vector<std::string> intv_paths;
-  if (!intv_list.empty()){
+  if (!intv_list.empty()) {
     intv_paths = split_by_nprocs(intv_list, "bed");
   }
   else {

--- a/src/worker-htc.cpp
+++ b/src/worker-htc.cpp
@@ -80,7 +80,13 @@ int htc_main(int argc, char** argv,
 
   std::vector<std::string> output_files(get_config<int>("gatk.ncontigs"));
 
-  std::vector<std::string> intv_paths = init_contig_intv(ref_path);
+  std::vector<std::string> intv_paths;
+  if (!intv_list.empty()) {
+    intv_paths = init_contig_intv(ref_path);
+  }
+  else {
+    intv_paths = split_by_nprocs(intv_list, "bed");
+  }
 
   // start an executor for NAM
   Worker_ptr blaze_worker(new BlazeWorker(

--- a/src/worker-ug.cpp
+++ b/src/worker-ug.cpp
@@ -26,7 +26,7 @@ int ug_main(int argc, char** argv,
     ("input,i", po::value<std::string>()->required(), "input BAM file or dir")
     ("output,o", po::value<std::string>()->required(), "output vcf file (if --skip-concat is set"
                                 "the output will be a directory of vcf files)")
-    ("intervalList,L", po::value<std::vector<std::string> >(), "interval list file")
+    ("intervalList,L", po::value<std::string>(), "interval list file")
     ("skip-concat,s", "produce a set of vcf files instead of one");
 
   // Parse arguments
@@ -47,7 +47,7 @@ int ug_main(int argc, char** argv,
   std::string ref_path    = get_argument<std::string>(cmd_vm, "ref", "r");
   std::string input_path  = get_argument<std::string>(cmd_vm, "input", "i");
   std::string output_path = get_argument<std::string>(cmd_vm, "output", "o");
-  std::vector<std::string> intv_list = get_argument<std::vector<std::string> >(cmd_vm, "intervalList", "L");
+  std::string intv_list   = get_argument<std::string>(cmd_vm, "intervalList", "L");
   std::vector<std::string> extra_opts = 
           get_argument<std::vector<std::string>>(cmd_vm, "extra-options", "O");
 
@@ -73,7 +73,13 @@ int ug_main(int argc, char** argv,
   create_dir(output_dir);
 
   std::vector<std::string> output_files(get_config<int>("gatk.ncontigs"));
-  std::vector<std::string> intv_paths = init_contig_intv(ref_path);
+  std::vector<std::string> intv_paths;
+  if (!intv_list.empty()) {
+    intv_paths = init_contig_intv(ref_path);
+  }
+  else {
+    intv_paths = split_by_nprocs(intv_list, "bed");
+  }
 
   Executor executor("Unified Genotyper", 
                     get_config<int>("gatk.ug.nprocs", "gatk.nprocs"));
@@ -96,7 +102,6 @@ int ug_main(int argc, char** argv,
           intv_paths[contig],
           output_file,
           extra_opts,
-          intv_list,
           flag_f));
     output_files[contig] = output_file;
 

--- a/src/workers/IndelWorker.cpp
+++ b/src/workers/IndelWorker.cpp
@@ -66,15 +66,13 @@ IndelWorker::IndelWorker(std::string ref_path,
       std::string target_path,
       std::string output_path,
       std::vector<std::string> extra_opts,
-      std::vector<std::string> &intv_list,
       bool &flag_f): 
   Worker(1, 1, extra_opts),
   ref_path_(ref_path),
   known_indels_(known_indels),
   intv_path_(intv_path),
   input_path_(input_path),
-  target_path_(target_path),
-  intv_list_(intv_list)
+  target_path_(target_path)
 {
   output_path_ = check_output(output_path, flag_f);
 }
@@ -103,14 +101,8 @@ void IndelWorker::setup() {
       << "-I " << input_path_ << " "
       // secret option to fix index fopen issue
       << "--disable_auto_index_creation_and_locking_when_reading_rods "
-      << "-o " << output_path_ << " ";
-
-  for (int i = 0; i < intv_list_.size(); i++) {
-    cmd << "-L " << intv_list_[i] << " ";
-  }
-  if (intv_list_.size() > 0 ) {
-    cmd << "-isr INTERSECTION ";
-  }
+      << "-o " << output_path_ << " "
+      << "-isr INTERSECTION ";
   
   for (int i = 0; i < known_indels_.size(); i++) {
     cmd << "-known " << known_indels_[i] << " ";

--- a/src/workers/UGWorker.cpp
+++ b/src/workers/UGWorker.cpp
@@ -12,13 +12,11 @@ UGWorker::UGWorker(std::string ref_path,
       std::string intv_path,
       std::string output_path,
       std::vector<std::string> extra_opts,
-      std::vector<std::string> &intv_list,
       bool &flag_f):
   Worker(1, get_config<int>("gatk.ug.nt"),extra_opts),
   ref_path_(ref_path),
   input_path_(input_path),
-  intv_path_(intv_path),
-  intv_list_(intv_list)
+  intv_path_(intv_path)
 {
   output_path_ = check_output(output_path, flag_f);
 }
@@ -42,14 +40,9 @@ void UGWorker::setup() {
       << "-I " << input_path_ << " "
       // secret option to fix index fopen issue
       << "--disable_auto_index_creation_and_locking_when_reading_rods "
-      << "-o " << output_path_ << " ";
+      << "-o " << output_path_ << " "
+      << "-isr INTERSECTION ";
 
-  for (int i = 0; i < intv_list_.size(); i++) {
-    cmd << "-L " << intv_list_[i] << " ";
-  }
-  if (intv_list_.size() > 0 ) {
-    cmd << "-isr INTERSECTION ";
-  }
   for (auto it = extra_opts_.begin(); it != extra_opts_.end(); it++) {
     cmd << it->first << " ";
     for( auto vec_iter = it->second.begin(); vec_iter != it->second.end(); vec_iter++) {


### PR DESCRIPTION
BQSR uses interval split to generate part bams, but htc still use reference split. As a result, the final vcf is wrong. 