### PR TITLE
change DepthWorker.cpp LOG to DLOG

### DIFF
--- a/src/workers/DepthWorker.cpp
+++ b/src/workers/DepthWorker.cpp
@@ -85,7 +85,7 @@ void DepthWorker::setup() {
   }
 
   cmd_ = cmd.str();
-  LOG(INFO) << cmd_;
+  DLOG(INFO) << cmd_;
 }
 
 } // namespace fcsgenome


### PR DESCRIPTION
checked every LOG(info). only 6 are found
./src/Executor.cpp:194:  LOG(INFO) << "Start doing " << job_name_;
./src/main.cpp:45:  LOG(INFO) << "Caught interrupt, cleaning up...";
./src/main.cpp:219:    LOG(INFO) << "Exiting program";
./src/workers/DepthWorker.cpp:88:  LOG(INFO) << cmd_;
./src/common.cpp:98:    LOG(INFO) << "Overwritting output '"
./include/fcs-genome/common.h:106:  LOG(INFO) << stage_name << " finishes in "

I suspect only the one in DepthWorker.cpp can be put in DLOG
