### PR TITLE
Fix tmpdir choice in sambamba sort

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -314,6 +314,8 @@ int init(char** argv, int argc) {
     arg_decl_int_w_def("mergebam.max_files",    4096, "max opened files in mergebam")
     arg_decl_int_w_def("mergebam.nt",           (16 > cpu_num ? cpu_num : 16),   "thread num in mergebam")
 
+    arg_decl_int_w_def("sort.nprocs",           32, "number of parallel sort processes to use")
+
     arg_decl_bool("gatk.scalout_mode", "enable scale-out mode for gatk")
     arg_decl_string_w_def("gatk.intv.path",    "", "default path to existing contig intervals")
     arg_decl_int_w_def("gatk.ncontigs", def_ncontigs, "default contig partition num in GATK steps")

--- a/src/worker-germline.cpp
+++ b/src/worker-germline.cpp
@@ -166,7 +166,7 @@ int germline_main(int argc, char** argv, boost::program_options::options_descrip
     // Loop through all the pairs of FASTQ files:
     for (int i = 0; i < list.size(); ++i) {
 
-      Executor executor("Falcon Fast Germline", num_buckets);
+      Executor executor("Falcon Fast Germline", get_config<int>("sort.nprocs", "gatk.nprocs"));
 
       std::string fq1_path    = list[i].fastqR1;
       std::string fq2_path    = list[i].fastqR2;

--- a/src/workers/SambambaWorker.cpp
+++ b/src/workers/SambambaWorker.cpp
@@ -71,19 +71,24 @@ void SambambaWorker::setup() {
     cmd << get_config<std::string>("sambamba_path") << " markdup "
         << "--overflow-list-size=" << get_config<int>("markdup.overflow-list-size") << " " 
         << inputBAMs.str() << " "
-        << "--tmpdir=" << get_config<std::string>("temp_dir") << " " << output_file_ << " "
+        << "--tmpdir=" << get_config<std::string>("temp_dir") << " " 
+        << output_file_ << " "
         << "-l 1 " << "-t " << get_config<int>("markdup.nt") << " ";
     break;
   case MERGE:
-    cmd << get_config<std::string>("sambamba_path") << " merge "  << output_file_ << " "
+    cmd << get_config<std::string>("sambamba_path") << " merge "  
+        << output_file_ << " "
         << inputBAMs.str() <<    " "
         << "-l 1 " << "-t " << get_config<int>("mergebam.nt") << " ";    
     break;
   case INDEX:
-    cmd << get_config<std::string>("sambamba_path") << " index " << output_file_ << " -t " << get_config<int>("mergebam.nt") << " ";
+    cmd << get_config<std::string>("sambamba_path") << " index " 
+        << output_file_ << " " 
+        << "-t " << get_config<int>("mergebam.nt") << " ";
     break;
   case SORT:
     cmd << get_config<std::string>("sambamba_path") << " sort " 
+        << "--tmpdir=" << get_config<std::string>("temp_dir") << " " 
         << input_path_ << ";";
     // mv bam and bai
     cmd << "mv " << get_fname_by_ext(input_path_, "sorted.bam") 


### PR DESCRIPTION
Also added a config option `sort.nprocs` to specify the number of concurrent sort processes. 