### PR TITLE
Gen 908 fix bqsr incorrect bed output

### DIFF
--- a/src/workers/BQSRWorker.cpp
+++ b/src/workers/BQSRWorker.cpp
@@ -197,8 +197,8 @@ void PRWorker::check() {
       if (boost::filesystem::exists(target_file)) {
          boost::filesystem::copy_file(target_file, get_fname_by_ext(output_path_, ext[j]), 
                                       boost::filesystem::copy_option::overwrite_if_exists);
-        // target file should be replace to a merged bed file.
-        // but add here to avoid breaking other things accidently.
+        // $target_file should be replaced to a merged bed file.
+        // But add here to avoid breaking other things accidently.(GEN-908)
         if (boost::filesystem::exists(input_path_.getInfo().mergedREGION[0])) {
           boost::filesystem::copy_file(input_path_.getInfo().mergedREGION[0], 
                                       get_fname_by_ext(output_path_, ext[j]),


### PR DESCRIPTION
Overwrite the bed files in the output recal.bam folder with the merged bed files.
The vector mergedREGION always has only one element, so it should be fine to use mergedREGION[0].

Tested align, bqsr, htc, germline commands using performance script with and without --disable-merge option.
